### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ruamel_yaml # anaconda
+ruamel_yaml<0.15 # anaconda
 
 # only for tests
 pytest >=3.0.3 # anaconda

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['ruamel_yaml'],
+    install_requires=['ruamel_yaml<0.15'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.